### PR TITLE
I suggest taking avr/bin from within Arduino.app

### DIFF
--- a/Arduino/ArduinoOnXcode2/Makefile
+++ b/Arduino/ArduinoOnXcode2/Makefile
@@ -1,5 +1,4 @@
 
-
 # Arduino UNO
 MCU = atmega328p
 F_CPU = 16000000
@@ -25,7 +24,8 @@ PORT = /dev/tty.usbmodem*
 
 ARDUINO = /Applications/Arduino.app/Contents/Resources/Java/hardware/arduino/cores/arduino
 LIBRARIES = /Applications/Arduino.app/Contents/Resources/Java/libraries
-AVRDUDE_DIR = /usr/local/CrossPack-AVR/bin
+AVRDUDE_DIR = /Applications/Arduino.app/Contents/Resources/Java/hardware/tools/avr/bin/
+
 SIZE = $(AVRDUDE_DIR)/avr-size
 SOURCES = $(wildcard src/*.cpp)
 


### PR DESCRIPTION
In order to improve consistency and avoid redundancy, 

I suggest taking avr/bin from within Arduino.app (or Mpide.app) instead of the /usr/local/CrossPack-AVR/bin.
